### PR TITLE
Fix html transition bug

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -14,6 +14,7 @@
 
 html {
   scroll-behavior: smooth;
+  height: 100%; /*Fix transition bug*/
 }
 
 html,


### PR DESCRIPTION
When you change the background color by dark/light the bottom of html doesn't change slowly when you have few posts. 

Because the html don't increase to the end of page.